### PR TITLE
Updating stylings, removing testing components

### DIFF
--- a/witchturnonline/src/Components/InitiativeScrollComponents/InitiativeComponents.js
+++ b/witchturnonline/src/Components/InitiativeScrollComponents/InitiativeComponents.js
@@ -8,11 +8,10 @@ import {
   StyledModalInterfaceDiv,
   StyledTTContentcontainer,
   StyledTTPicture,
-  StyledTTPictureOption,
   StyledTurnContainer,
   StyledTurnTaker,
   StyledTTPictureSelectorButton,
-  StyledPictureSelectorRoll,
+  StyledTurnandAddButton,
 } from "../StyledComponents/InitiativeStyles";
 import {
   StyledFormInformationRow,
@@ -32,7 +31,7 @@ function InitiativeRoll(props) {
             img={character.img}
             initiative={character.initiative}
             bonus={character.bonus}
-            placement={index}
+            position={index}
             RemoveParticipant={props.RemoveParticipant}
             key={(character.initiative, character.bonus, character.name, index)}
           />
@@ -44,7 +43,7 @@ function InitiativeRoll(props) {
 
 function TurnTaker(props) {
   return (
-    <StyledTurnTaker>
+    <StyledTurnTaker position={props.position}>
       <StyledTTContentcontainer>
         <StyledTTPicture src={props.img} />
         <StyledInfoLabel>
@@ -69,7 +68,7 @@ function TurnTaker(props) {
         <StyledXButton
           buttonSize={"40px"}
           onClick={() => {
-            props.RemoveParticipant(props.placement);
+            props.RemoveParticipant(props.position);
           }}
         >
           X
@@ -93,14 +92,14 @@ function ChangePositionButton(props) {
 
 function CompleteModalButton(props) {
   return (
-    <StyledGenericButton
+    <StyledTurnandAddButton
       onClick={() => {
         props.CompleteModalFunction();
         props.SetVisible(false);
       }}
     >
       {props.children}
-    </StyledGenericButton>
+    </StyledTurnandAddButton>
   );
 }
 

--- a/witchturnonline/src/Components/InitiativeScrollComponents/InitiativeComponents.js
+++ b/witchturnonline/src/Components/InitiativeScrollComponents/InitiativeComponents.js
@@ -64,10 +64,7 @@ function TurnTaker(props) {
               : "")}
         </StyledInfoLabel>
       </StyledTTContentcontainer>
-      <StyledTTContentcontainer>
-        <ChangePositionButton>Increase Position</ChangePositionButton>
-        <ChangePositionButton>Decreate Position</ChangePositionButton>
-      </StyledTTContentcontainer>
+      <StyledTTContentcontainer></StyledTTContentcontainer>
       <StyledTTContentcontainer>
         <StyledXButton
           buttonSize={"40px"}
@@ -149,6 +146,7 @@ function AddModal(props) {
         <StyledFormInformationRow>
           <StyledInfoLabel>Initiative: </StyledInfoLabel>
           <LimitedInputCombo
+            lettersNotAllowed={true}
             setInputState={(value) => {
               initiative.current = value;
             }}
@@ -160,6 +158,7 @@ function AddModal(props) {
         <StyledFormInformationRow>
           <StyledInfoLabel>Bonus: </StyledInfoLabel>
           <LimitedInputCombo
+            lettersNotAllowed={true}
             setInputState={(value) => {
               bonus.current = value;
             }}

--- a/witchturnonline/src/Components/SearchBars/GenericInputs.js
+++ b/witchturnonline/src/Components/SearchBars/GenericInputs.js
@@ -14,10 +14,15 @@ function LimitedInputCombo(props) {
       textAlignment={props.textAlignment}
       backgroundColor={props.backgroundColor}
       letterSpacing={props.letterSpacing}
-      onInput={
-        props.onInputFunction
-          ? (event) => props.onInputFunction(event)
-          : (event) => onInputFunction(event)
+      onInput={(event) => onInputFunction(event)}
+      onKeyUp={
+        props.lettersNotAllowed
+          ? (event) => {
+              let replacement = event.target.value.replace(/[^a-z]/, "");
+              event.target.value = replacement;
+              props.setInputState(replacement);
+            }
+          : () => {}
       }
     ></StyleableLimitedInput>
   );

--- a/witchturnonline/src/Components/StyledComponents/ColorStyles.js
+++ b/witchturnonline/src/Components/StyledComponents/ColorStyles.js
@@ -1,6 +1,7 @@
 const DarkColorStyles = {
   DeepBackgroundPurple: "#0B0016",
   GreyPurpleBackground: "#3C1F66",
+  LighterGreyPurpleBackground: "#5C3F86",
   GreyPurpleBackgroundRGB: "60, 31, 102",
   DarkPurpleBackground: "#2B0066",
   GreyPurpleForeground: "#4B00B3",

--- a/witchturnonline/src/Components/StyledComponents/InitiativeStyles.js
+++ b/witchturnonline/src/Components/StyledComponents/InitiativeStyles.js
@@ -40,8 +40,8 @@ const StyledTurnTaker = styled.div`
   align-items: center;
 
   background-color: ${(props) =>
-    props.backgroundColor
-      ? props.backgroundColor
+    props.position == 0
+      ? DarkColorStyles.LighterGreyPurpleBackground
       : DarkColorStyles.GreyPurpleBackground};
 `;
 
@@ -70,6 +70,21 @@ const StyledTTPictureSelectorButton = styled(StyledTTPicture)`
   transition: ease all 0.4s;
   :hover {
     box-shadow: 4px 4px 4px black;
+  }
+`;
+
+const StyledTurnandAddButton = styled.button`
+  color: white;
+  font-weight: bold;
+  border: 2px ${DarkColorStyles.PurpleHighlight} solid;
+  padding: 10px;
+  font-size: 1em;
+  border-radius: 10px;
+  background-color: ${DarkColorStyles.LightPurpleForeground};
+  transition: ease all 0.4s;
+
+  :hover {
+    box-shadow: 3px 3px 3px ${DarkColorStyles.PurpleBoxShadow};
   }
 `;
 
@@ -142,5 +157,6 @@ export {
   StyledPictureSelectorRoll,
   StyledTTPictureOption,
   StyledLeftRightButton,
+  StyledTurnandAddButton,
   StyledButtonRow,
 };

--- a/witchturnonline/src/Pages/Base20InitiativePage.js
+++ b/witchturnonline/src/Pages/Base20InitiativePage.js
@@ -9,7 +9,10 @@ import {
 import wizard from "../Assets/Wizard.png";
 import gobo from "../Assets/GoboTest.png";
 import { useEffect, useState } from "react";
-import { StyledButtonRow } from "../Components/StyledComponents/InitiativeStyles";
+import {
+  StyledButtonRow,
+  StyledTurnandAddButton,
+} from "../Components/StyledComponents/InitiativeStyles";
 
 function Base20InitiativePage(props) {
   const [participants, setParticipants] = useState([]);
@@ -178,13 +181,13 @@ function Base20InitiativePage(props) {
       </DefaultPageColumn>
       <DefaultPageColumn flexGrow={2} modalOn={addModalVisible}>
         <label>Room: {props.room}</label>
-        <button
+        <StyledTurnandAddButton
           onClick={() => {
             setAddModalVisible(true);
           }}
         >
           Add Participant
-        </button>
+        </StyledTurnandAddButton>
       </DefaultPageColumn>
     </DefaultPageBody>
   );

--- a/witchturnonline/src/Pages/Base20InitiativePage.js
+++ b/witchturnonline/src/Pages/Base20InitiativePage.js
@@ -12,10 +12,7 @@ import { useEffect, useState } from "react";
 import { StyledButtonRow } from "../Components/StyledComponents/InitiativeStyles";
 
 function Base20InitiativePage(props) {
-  const [participants, setParticipants] = useState([
-    { name: "Bianchi", img: wizard, initiative: 1, bonus: 3 },
-    { name: "momo", img: gobo, initiative: 13, bonus: 2 },
-  ]);
+  const [participants, setParticipants] = useState([]);
 
   const [offset, setOffset] = useState(0);
 

--- a/witchturnonline/src/Pages/JoinRoomPage.js
+++ b/witchturnonline/src/Pages/JoinRoomPage.js
@@ -41,7 +41,7 @@ function JoinRoomPage(props) {
 
   useEffect(() => {
     props.socket.on("room_not_valid", (data) => {
-      console.log(`the room ${data.room} is not valid`);
+      alert(`That room has not yet been made`);
       setCheckingRoomValidity(false);
     });
 


### PR DESCRIPTION
I have updated some of the button stylings, and removed some of the components which were used to diagnose issues with the code. Primarily this includes changes to the initial contents of the turn order.

-button stylings has changed. I will need to revisit this later.
-The first person in the turn order is now a lighter color of grey-purple.
-The turn order now starts empty.
-failing to join a room triggers an alert, rather than a console log.